### PR TITLE
SharedMemory wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,6 @@ if(UNIX)
     target_link_libraries(${PROJECT_NAME} PRIVATE rt)
   endif()
 endif()
-set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++")
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME _pycluon)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED true)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,9 +47,12 @@ target_include_directories(${PROJECT_NAME}
   ${CMAKE_CURRENT_BINARY_DIR}/include # libcluon "built-in" message specifications
 
 )
-target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads cluon-static)
+target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads cluon-static -static-libgcc -static-libstdc++)
+if(UNIX)
+  target_link_libraries(${PROJECT_NAME} PRIVATE rt)
+endif()
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME _pycluon)
-set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED true)
+set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED true)
 
 add_dependencies(${PROJECT_NAME} cluon-msc)
 add_dependencies(${PROJECT_NAME} cluon-OD4toStdout)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,10 +47,13 @@ target_include_directories(${PROJECT_NAME}
   ${CMAKE_CURRENT_BINARY_DIR}/include # libcluon "built-in" message specifications
 
 )
-target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads cluon-static -static-libgcc -static-libstdc++)
+target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads cluon-static)
 if(UNIX)
-  target_link_libraries(${PROJECT_NAME} PRIVATE rt)
+  if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+    target_link_libraries(${PROJECT_NAME} PRIVATE rt)
+  endif()
 endif()
+set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++")
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME _pycluon)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED true)
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ So far, `pycluon` wraps the following concepts from libcluon:
 * UDPReceiver
 * TCPConnection
 * TCPServer
+* SharedMemory
 
 It also bundles the following command-line applications:
 * protoc
@@ -29,6 +30,7 @@ It also bundles the following command-line applications:
 |             0.1.1 |            0.0.140 |
 |             0.1.2 |            0.0.140 |
 |             0.1.3 |            0.0.140 |
+|             0.2.0 |            0.0.140 |
 
 ## Installation
 
@@ -81,6 +83,33 @@ session.add_data_trigger(13, callback)
 
 while session.is_running():
     time.sleep(0.01)
+```
+
+**Write to a shared memory area**
+```python
+from datetime import datetime
+from pycluon import SharedMemory
+
+sm = SharedMemory("frame.argb", 640*480)
+
+sm.lock()
+sm.timestamp = datetime.now()
+sm.data = b"<bytes>"
+sm.unlock()
+sm.notify_all()
+```
+
+**Read from an existing shared memory area**
+```python
+from pycluon import SharedMemory
+
+sm = SharedMemory("frame.argb")
+
+sm.wait() # Wait for notification from writing process
+sm.lock()
+print(sm.timestamp)
+print(sm.data)
+sm.unlock()
 ```
 
 See the [tests](tests/test_libcluon_wrappers.py#L87-L143) for usage of `UDPSender`, `UDPReceiver`, `TCPConnection` and `TCPServer`.

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name="pycluon",
-    version="0.1.3",
+    version="0.2.0",
     license="Apache License 2.0",
     description="A python wrapper around libcluon",
     long_description=read("README.md"),

--- a/tests/test_libcluon_wrappers.py
+++ b/tests/test_libcluon_wrappers.py
@@ -1,7 +1,7 @@
 import time
 import gc
+import sys
 import threading
-import multiprocessing
 from datetime import datetime
 
 import pytest
@@ -153,6 +153,10 @@ def test_TCP_ping():
     assert CALLED_ON_CONNECTION_LOST
 
 
+# @pytest.mark.skipif(
+#     sys.platform == "win32" or sys.platform == "darwin",
+#     reason="See issue https://github.com/MO-RISE/pycluon/issues/11",
+# )
 def test_shared_memory():
     sm = SharedMemory("trial.data", 10)
     sm2 = SharedMemory("trial.data")

--- a/tests/test_libcluon_wrappers.py
+++ b/tests/test_libcluon_wrappers.py
@@ -29,17 +29,14 @@ def test_envelope_setters_getters():
     assert e.serialized_data == b"muppet"
 
     assert isinstance(e.sent_at, datetime)
-    assert e.sent_at.timestamp() == 0.0
     e.sent_at = datetime.fromtimestamp(347238.438274)
     assert e.sent_at.timestamp() == 347238.438274
 
     assert isinstance(e.received_at, datetime)
-    assert e.received_at.timestamp() == 0.0
     e.received_at = datetime.fromtimestamp(347238.438274)
     assert e.received_at.timestamp() == 347238.438274
 
     assert isinstance(e.sampled_at, datetime)
-    assert e.sampled_at.timestamp() == 0.0
     e.sampled_at = datetime.fromtimestamp(347238.438274)
     assert e.sampled_at.timestamp() == 347238.438274
 
@@ -153,10 +150,10 @@ def test_TCP_ping():
     assert CALLED_ON_CONNECTION_LOST
 
 
-# @pytest.mark.skipif(
-#     sys.platform == "win32" or sys.platform == "darwin",
-#     reason="See issue https://github.com/MO-RISE/pycluon/issues/11",
-# )
+@pytest.mark.skipif(
+    sys.platform == "win32" or sys.platform == "darwin",
+    reason="See issue https://github.com/MO-RISE/pycluon/issues/11",
+)
 def test_shared_memory():
     sm = SharedMemory("trial.data", 10)
     sm2 = SharedMemory("trial.data")


### PR DESCRIPTION
Introducing wrapper of cluon::SharedMemory

Now also using datetime.datetime <-> std::chrono::system_clock::timepoint for all timestamp conversions across pybind border
