### PR TITLE
Bumping the pybind version to 2.10.4

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', '3.11']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ CPMAddPackage(
 CPMAddPackage(
   NAME pybind11
   GITHUB_REPOSITORY pybind/pybind11
-  GIT_TAG v2.6.1
+  GIT_TAG v2.10.4
 )
 
 


### PR DESCRIPTION
To support Python 3.11, see:
https://github.com/IntelRealSense/librealsense/issues/11142